### PR TITLE
Add travis ci build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+go:
+  - 1.1
+  - 1.2
+  - 1.3
+  - 1.4
+  - release
+  - tip
+
+script:
+  - go get github.com/kisielk/errcheck
+  - go get -t ./...
+
+  - go test -v ./...
+  - go test -race ./...
+  - errcheck github.com/pressly/chainstore
+


### PR DESCRIPTION
Linter and vet tool can be run as well. Currently it will run tests for all go versions.
You need to register this repository on [travis-ci](https://travis-ci.org/repositories)