### PR TITLE
Replacing metrics library

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ func main() {
 	ctx := context.Background()
 
 	diskStore := lrumgr.New(500*1024*1024, // 500MB of working data
-		metricsmgr.New("chainstore.ex.bolt", nil,
+		metricsmgr.New("chainstore.ex.bolt",
 			boltstore.New("/tmp/store.db", "myBucket"),
 		),
 	)
 
-	remoteStore := metricsmgr.New("chainstore.ex.s3", nil,
+	remoteStore := metricsmgr.New("chainstore.ex.s3",
 		// NOTE: you'll have to supply your own keys in order for this example to work properly
 		s3store.New(bucketID, accessKey, secretKey),
 	)
@@ -63,11 +63,11 @@ func main() {
 	/*
 		dataStore := chainstore.New(
 			lrumgr.New(500*1024*1024, // 500MB of working data
-				metricsmgr.New("chainstore.ex.bolt", nil,
+				metricsmgr.New("chainstore.ex.bolt",
 					boltstore.New("/tmp/store.db", "myBucket"),
 				),
 			),
-			metricsmgr.New("chainstore.ex.s3", nil,
+			metricsmgr.New("chainstore.ex.s3",
 				// NOTE: you'll have to supply your own keys in order for this example to work properly
 				s3store.New("myBucket", "access-key", "secret-key"),
 			),

--- a/chainstore_test.go
+++ b/chainstore_test.go
@@ -94,7 +94,7 @@ func TestAsyncChain(t *testing.T) {
 		ms,
 		chainstore.Async(
 			logmgr.New(logger, "async"),
-			metricsmgr.New("chaintest", nil,
+			metricsmgr.New("chaintest",
 				fs,
 				lrumgr.New(100, bs),
 			),

--- a/example/main.go
+++ b/example/main.go
@@ -30,12 +30,12 @@ func main() {
 	ctx := context.Background()
 
 	diskStore := lrumgr.New(500*1024*1024, // 500MB of working data
-		metricsmgr.New("chainstore.ex.bolt", nil,
+		metricsmgr.New("chainstore.ex.bolt",
 			boltstore.New("/tmp/store.db", "myBucket"),
 		),
 	)
 
-	remoteStore := metricsmgr.New("chainstore.ex.s3", nil,
+	remoteStore := metricsmgr.New("chainstore.ex.s3",
 		// NOTE: you'll have to supply your own keys in order for this example to work properly
 		s3store.New(bucketID, accessKey, secretKey),
 	)
@@ -46,11 +46,11 @@ func main() {
 	/*
 		dataStore := chainstore.New(
 			lrumgr.New(500*1024*1024, // 500MB of working data
-				metricsmgr.New("chainstore.ex.bolt", nil,
+				metricsmgr.New("chainstore.ex.bolt",
 					boltstore.New("/tmp/store.db", "myBucket"),
 				),
 			),
-			metricsmgr.New("chainstore.ex.s3", nil,
+			metricsmgr.New("chainstore.ex.s3",
 				// NOTE: you'll have to supply your own keys in order for this example to work properly
 				s3store.New("myBucket", "access-key", "secret-key"),
 			),

--- a/metricsmgr/metrics_manager_test.go
+++ b/metricsmgr/metrics_manager_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/pressly/chainstore"
-	"github.com/rcrowley/go-metrics"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
@@ -17,7 +16,7 @@ func TestMetricsMgrStore(t *testing.T) {
 
 	assert := assert.New(t)
 
-	store = chainstore.New(New("ns", metrics.DefaultRegistry))
+	store = chainstore.New(New("ns"))
 	err = store.Open()
 	assert.Nil(err)
 	defer store.Close()


### PR DESCRIPTION
Using `github.com/armon/go-metrics` instead of `github.com/rcrowley/go-metrics`. Closes #15 