### PR TITLE
Copy byte slice from boltdb transaction

### DIFF
--- a/boltstore/bolt_store.go
+++ b/boltstore/bolt_store.go
@@ -81,7 +81,9 @@ func (s *boltStore) Get(ctx context.Context, key string) (val []byte, err error)
 	default:
 		err = s.db.View(func(tx *bolt.Tx) error {
 			b := tx.Bucket(s.bucketName)
-			val = b.Get([]byte(key))
+			raw := b.Get([]byte(key))
+			val = make([]byte, len(raw))
+			copy(val, raw)
 			return nil
 		})
 		return


### PR DESCRIPTION
Per the [boltdb docs](https://godoc.org/github.com/boltdb/bolt#Bucket.Get), the byte slice returned from `b.Get()` is only valid while the transaction is open. Therefore the slice needs to by copied before being used elsewhere.